### PR TITLE
Remove `allowed_push_host` setting from gem spec

### DIFF
--- a/protoc-gen-twirp_ruby.gemspec
+++ b/protoc-gen-twirp_ruby.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/collectiveidea/protoc-gen-twirp_ruby"
   spec.metadata["changelog_uri"] = "https://github.com/collectiveidea/protoc-gen-twirp_ruby/blob/main/CHANGELOG.md"


### PR DESCRIPTION
We want to publish on rubygems, not privately, per https://guides.rubygems.org/publishing/