### PR TITLE
Remove unnecessary extra files from packaged gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Remove unnecessary extra files from packaged gem
+
 ## [1.0.0] - 2024-05-10
 
 - Initial release

--- a/protoc-gen-twirp_ruby.gemspec
+++ b/protoc-gen-twirp_ruby.gemspec
@@ -27,7 +27,18 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[
+          .github/
+          bin/
+          example/
+          proto/
+          spec/
+          .git
+          .rspec
+          .standard
+          Gemfile
+          Rakefile
+        ])
     end
   end
   spec.bindir = "exe"


### PR DESCRIPTION
This removes some extra files from the packaged gem that don't need to be there:

 - .rpsec
 - Rakefile
 - proto files that were used to generate the ruby code to process the protoc plugin messages
 - example files
 - standardrb config file