### PR TITLE
Update README.md with new release instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,15 @@ protoc --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto
 
 To release a new version:
 
- * Update the version number in `version.rb`
- * Update the CHANGELOG.md
-     * Create a section for the new version and move the unreleased version there
- * Re-generate the example:
-     * `protoc --plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto`
- * Submit a PR; see [#30](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/30)
- * Once merged, create and push the tag. This releases to RubyGems.
-    *  `git tag v<version> && git push origin --tags`
+ * Submit a PR with the following changes (see [#30](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/30)):
+   * Update the version number in `version.rb`
+   * Update the CHANGELOG.md
+       * Create a section for the new version and move the unreleased version there
+   * Re-generate the example:
+       * `protoc --plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto`
+ * Once merged, run the release task from main. Note that we prepend `gem_push=no` to avoid
+   pushing to RubyGems directly; our GitHub publish action will do this for us.
+    *  `gem_push=no bundle exec rake release`
  * Create a GitHub release: 
      * `gh release create v<version>`
      * Edit the release notes to link to the notes in the CHANGELOG.md for the version

--- a/README.md
+++ b/README.md
@@ -97,7 +97,19 @@ protoc --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto
 
 ## Releasing
 
-To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To release a new version:
+
+ * Update the version number in `version.rb`
+ * Update the CHANGELOG.md
+     * Create a section for the new version and move the unreleased version there
+ * Re-generate the example:
+     * `protoc --plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto`
+ * Submit a PR; see [#30](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/30)
+ * Once merged, create and push the tag. This releases to RubyGems.
+    *  `git tag v<version> && git push origin --tags`
+ * Create a GitHub release: 
+     * `gh release create v<version>`
+     * Edit the release notes to link to the notes in the CHANGELOG.md for the version
 
 ## Contributing
 


### PR DESCRIPTION
Instead of `bundle exec rake release` that pushes to RubyGems from a local build, let's use GitHub as a trusted publisher moving forward.

There's still a lot of manual wrangling here. Tempted to wrap more of this up into a rake task to make it simpler, less steps, and less error-prone. That's a future effort.