### PR TITLE
Remove racc dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        cache-version: 1
     - name: Run the default task
       run: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-- Nothing (yet)
+- Remove unnecessary `racc` runtime dependency - [#33](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/33)
 
 ## [1.1.0] - 2024-05-21
 

--- a/protoc-gen-twirp_ruby.gemspec
+++ b/protoc-gen-twirp_ruby.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "google-protobuf"
-  spec.add_dependency "racc"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
It is a transitive dependency of standard (via rubocop via parser) but not one we depend on explicitly.

Not having it was [previously causing test failures](https://github.com/collectiveidea/protoc-gen-twirp_ruby/actions/runs/8952742311/job/24590458127).