### PR TITLE
Add development rake task to generate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,20 @@ that might affect migration include:
  * Generated output code is in [standardrb style](https://github.com/standardrb/standard).
  * Generated service and client class names are improved for well-named protobuf services. See [#6](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/6).
  * Supports `ruby_package` in `.proto` files
- * Supports various protoc command line [configuration options](https://github.com/collectiveidea/protoc-gen-twirp_ruby?tab=readme-ov-file#options).
-
+ * Supports various protoc command line [configuration options](#options).
 
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-For continued development purposes, we can route `protoc` to the local repo code for the plugin and generate against the example via:
+To experiment with development changes, route `protoc` to the local plugin when generating code
+via the `--plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby` option. For example:
 
 ```bash
 protoc --plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto
 ```
 
-The local code for the gem can also be installed via `bundle exec rake install` to omit the `--plugin=protoc-gen-twirp_ruby=` option from `protoc`:
+Alternatively, install the local gem before invoking `protoc`:
 
 ```bash
 bundle exec rake install
@@ -110,14 +110,13 @@ To release a new version:
  * Submit a PR with the following changes (see [#30](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/30)):
    * Update the version number in `version.rb`
    * Update the CHANGELOG.md
-       * Create a section for the new version and move the unreleased version there
-   * Re-generate the example:
-       * `protoc --plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby --ruby_out=. --twirp_ruby_out=. ./example/hello_world.proto`
+     * Create a section for the new version and move the unreleased version there
+   * Re-generate the example: `bundle exec rake example`
  * Once merged, run the release task from main. Note that we prepend `gem_push=no` to avoid
    pushing to RubyGems directly; our GitHub publish action will do this for us.
-    *  `gem_push=no bundle exec rake release`
+   *  `gem_push=no bundle exec rake release`
  * Create a GitHub release: 
-     * `gh release create v<version>`
+   * `gh release create v<version>`
      * Edit the release notes to link to the notes in the CHANGELOG.md for the version
 
 ## Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,8 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "standard/rake"
 
+# Load development-only rake tasks. There are in `tasks/` and not
+# `lib/tasks/` because we don't want to ship them with the gem.
+Rake.add_rakelib "tasks"
+
 task default: %i[spec standard]

--- a/protoc-gen-twirp_ruby.gemspec
+++ b/protoc-gen-twirp_ruby.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
           example/
           proto/
           spec/
+          tasks/
           .git
           .rspec
           .standard

--- a/tasks/twirp_protoc_plugin.rake
+++ b/tasks/twirp_protoc_plugin.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rake"
+
+desc "Re-runs code generation for the example using local plugin code."
+task :example do
+  %x(protoc --plugin=protoc-gen-twirp_ruby=./exe/protoc-gen-twirp_ruby \
+      --ruby_out=. \
+      --twirp_ruby_out=. \
+      ./example/hello_world.proto
+  )
+end


### PR DESCRIPTION
Improve development quality-of-life by adding a rake task that runs the code generator for the example. No more having to look up the right command to use... `bundle exec rake example` does the trick.

Since this is a development-only task, and not one that we should ship with the gem, it's in `tasks/` instead of `lib/tasks`.