### PR TITLE
GitHub Action improvements

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,6 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.0'
+          - '3.1'
+          - '3.2'
           - '3.3.1'
 
     steps:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: rspec
 
 on:
   push:
@@ -24,5 +24,5 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
         cache-version: 1
-    - name: Run the default task
-      run: bundle exec rake
+    - name: Run RSpec
+      run: bundle exec rake spec

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -1,0 +1,23 @@
+name: standardrb
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.1
+          bundler-cache: true
+          cache-version: 1
+      - name: Run Standard Ruby
+        run: bundle exec rake standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Update GitHub action to run specs on all supported Ruby versions - [#37](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/37)
+
 ## [1.1.1] - 2024-05-22
 
 - Remove unnecessary `racc` runtime dependency - [#33](https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/33)


### PR DESCRIPTION
Parallelize `rake standard` and `rake spec` by splitting out separate actions.

Add all supported Ruby versions to the spec matrix, to ensure that all specs pass everywhere.