### PR TITLE
Tweak publish action to only build and push

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -24,5 +24,6 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
-      # Release
-      - uses: rubygems/release-gem@v1
+      # Build and Release
+      - name: Build and Release to RubyGems
+        run: bundle exec rake build release:rubygem_push

--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -24,6 +24,8 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
-      # Build and Release
+      - name: Configure trusted publishing credentials
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+
       - name: Build and Release to RubyGems
         run: bundle exec rake build release:rubygem_push


### PR DESCRIPTION
Previously the action was running `bundle exec rake release`, which was doing too much, and broke after #41 since the `release` task is meant to be run on a local development machine.

The GitHub publish_gem action automatically runs when a release tag is pushed. The only thing the action should do is build the gem and publish to RubyGems.