### PR TITLE
Add Coveralls Action and README badge for code coverage

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     env:
       COVERAGE: true
 
@@ -34,3 +34,18 @@ jobs:
 
     - name: Run RSpec
       run: bundle exec rake spec
+
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@v2
+      with:
+        flag-name: run-${{ matrix.ruby }}
+        parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,5 +19,6 @@ jobs:
           ruby-version: 3.4.7
           bundler-cache: true
           cache-version: 1
+
       - name: Run Standard Ruby
         run: bundle exec rake standard

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Gem Version](https://img.shields.io/gem/v/protoc-gen-twirp_ruby.svg)](https://rubygems.org/gems/protoc-gen-twirp_ruby)
 [![Specs](https://github.com/collectiveidea/protoc-gen-twirp_ruby/actions/workflows/rspec.yml/badge.svg)](https://github.com/collectiveidea/protoc-gen-twirp_ruby/actions/workflows/rspec.yml)
 [![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/standardrb/standard)
+[![Coverage Status](https://coveralls.io/repos/github/collectiveidea/protoc-gen-twirp_ruby/badge.svg)](https://coveralls.io/github/collectiveidea/protoc-gen-twirp_ruby)
 
 # protoc-gen-twirp_ruby - A `protoc` plugin for Twirp-Ruby.
 


### PR DESCRIPTION
Code Climate is deprecated and was failing the build, so we removed test coverage reporting in https://github.com/collectiveidea/protoc-gen-twirp_ruby/pull/44/commits/55dcb8791b6deb8070855acbdc2b096d051d8e84

This brings test coverage reporting and analysis back via the [Coveralls action](https://github.com/marketplace/actions/coveralls-github-action) which reports to https://coveralls.io/github/collectiveidea/protoc-gen-twirp_ruby instead.

And we get our nice README coverage badge back.